### PR TITLE
fix: Make codecov checks informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,11 +16,15 @@ coverage:
         target: 70%
         # Allow coverage to drop by 2% without failing
         threshold: 2%
+        # Don't fail the CI if coverage targets aren't met
+        informational: true
         
     patch:
       default:
         # New code must have at least 80% coverage
         target: 80%
+        # Don't fail the CI if coverage targets aren't met
+        informational: true
         
     changes: false
 
@@ -46,6 +50,7 @@ component_management:
       - type: project
         target: auto
         threshold: 1%
+        informational: true
         
   individual_components:
     - component_id: langfuse-client-base


### PR DESCRIPTION
## Description

This PR updates the codecov configuration to make all coverage checks informational rather than blocking.

## Changes

- Added `informational: true` to project coverage status
- Added `informational: true` to patch coverage status  
- Added `informational: true` to component coverage status

## Why This Change?

Currently, codecov checks are failing on PRs (like #7) even for documentation-only changes. This blocks merging of valid contributions.

With this change:
- ✅ Coverage reports are still generated and visible
- ✅ We can still monitor code coverage trends
- ✅ PRs won't be blocked by coverage requirements
- ✅ Documentation and configuration changes can be merged

## Impact

- Coverage information remains available for review
- CI status will show as passing even if coverage targets aren't met
- Coverage comments on PRs will still appear with statistics

## Testing

This change only affects CI behavior. The codecov configuration will be validated when codecov processes it.